### PR TITLE
fix(opencode): generate valid tools object and MCP command array for OpenCode schema compliance

### DIFF
--- a/pkg/@eserstack/noskills/sync/adapters/opencode.test.ts
+++ b/pkg/@eserstack/noskills/sync/adapters/opencode.test.ts
@@ -246,7 +246,7 @@ describe("OpenCode adapter: snapshot tests", () => {
       assertStringIncludes(content, "name: noskills-executor");
     });
 
-    it("noskills-executor.md has tools list including write, shell, delegate", async () => {
+    it("noskills-executor.md has tools object with all required keys", async () => {
       const ctx = makeCtx(tempDir);
       await opencodeAdapterMod.opencodeAdapter.syncAgents!(ctx);
 
@@ -254,9 +254,17 @@ describe("OpenCode adapter: snapshot tests", () => {
         `${tempDir}/.opencode/agents/noskills-executor.md`,
       );
 
-      assertStringIncludes(content, "write");
-      assertStringIncludes(content, "shell");
-      assertStringIncludes(content, "delegate");
+      const toolsMatch = content.match(/\ntools:\n((?:[ ]{2}\w+: [^\n]+\n)+)/);
+      assert(toolsMatch !== null, "tools section not found in YAML frontmatter");
+
+      const toolsBlock = toolsMatch![1]!;
+      assertStringIncludes(toolsBlock, "read: true");
+      assertStringIncludes(toolsBlock, "write: true");
+      assertStringIncludes(toolsBlock, "glob: true");
+      assertStringIncludes(toolsBlock, "grep: true");
+      assertStringIncludes(toolsBlock, "shell: true");
+      assertStringIncludes(toolsBlock, "delegate: true");
+      assertEquals(toolsBlock.includes(","), false, "tools should not use comma-separated format");
     });
 
     it("noskills-verifier.md has YAML frontmatter with name: noskills-verifier", async () => {
@@ -271,7 +279,7 @@ describe("OpenCode adapter: snapshot tests", () => {
       assertStringIncludes(content, "name: noskills-verifier");
     });
 
-    it("noskills-verifier.md has read-only tool set (no write)", async () => {
+    it("noskills-verifier.md has read-only tools object (no write, no delegate)", async () => {
       const ctx = makeCtx(tempDir);
       await opencodeAdapterMod.opencodeAdapter.syncAgents!(ctx);
 
@@ -279,19 +287,16 @@ describe("OpenCode adapter: snapshot tests", () => {
         `${tempDir}/.opencode/agents/noskills-verifier.md`,
       );
 
-      // Extract frontmatter tools line
-      const toolsMatch = content.match(/^tools:\s*(.+)$/m);
-      assert(toolsMatch !== null);
+      const toolsMatch = content.match(/\ntools:\n((?:[ ]{2}\w+: [^\n]+\n)+)/);
+      assert(toolsMatch !== null, "tools section not found in YAML frontmatter");
 
-      const toolsList = toolsMatch![1]!;
-
-      // Should have read-only tools
-      assertStringIncludes(toolsList, "read");
-      assertStringIncludes(toolsList, "shell");
-
-      // Should NOT have write or delegate
-      assertEquals(toolsList.includes("write"), false);
-      assertEquals(toolsList.includes("delegate"), false);
+      const toolsBlock = toolsMatch![1]!;
+      assertStringIncludes(toolsBlock, "read: true");
+      assertStringIncludes(toolsBlock, "glob: true");
+      assertStringIncludes(toolsBlock, "grep: true");
+      assertStringIncludes(toolsBlock, "shell: true");
+      assertEquals(toolsBlock.includes("write"), false);
+      assertEquals(toolsBlock.includes("delegate"), false);
     });
   });
 
@@ -433,7 +438,7 @@ describe("OpenCode adapter: snapshot tests", () => {
   // ---------------------------------------------------------------------------
 
   describe("syncMcp: opencode.json", () => {
-    it("has mcp.noskills entry with type: local", async () => {
+    it("has mcp.noskills entry with type: local and enabled: true", async () => {
       const ctx = makeCtx(tempDir);
       await opencodeAdapterMod.opencodeAdapter.syncMcp!(ctx);
 
@@ -445,9 +450,10 @@ describe("OpenCode adapter: snapshot tests", () => {
       assert(parsed.mcp !== undefined);
       assert(parsed.mcp.noskills !== undefined);
       assertEquals(parsed.mcp.noskills.type, "local");
+      assertEquals(parsed.mcp.noskills.enabled, true);
     });
 
-    it("has command field (string) and args array ending with mcp-serve", async () => {
+    it("has command array ending with mcp-serve", async () => {
       const ctx = makeCtx(tempDir);
       await opencodeAdapterMod.opencodeAdapter.syncMcp!(ctx);
 
@@ -456,12 +462,10 @@ describe("OpenCode adapter: snapshot tests", () => {
       );
       const parsed = JSON.parse(raw);
 
-      assertEquals(typeof parsed.mcp.noskills.command, "string");
-      assert(parsed.mcp.noskills.command.length > 0);
-
-      const args = parsed.mcp.noskills.args;
-      assert(Array.isArray(args));
-      assertEquals(args[args.length - 1], "mcp-serve");
+      const cmd = parsed.mcp.noskills.command;
+      assert(Array.isArray(cmd));
+      assert(cmd.length > 0);
+      assertEquals(cmd[cmd.length - 1], "mcp-serve");
     });
 
     it("preserves existing non-noskills config in opencode.json", async () => {
@@ -614,7 +618,7 @@ describe("OpenCode adapter: structure validation", () => {
   // ---------------------------------------------------------------------------
 
   describe("MCP JSON structure", () => {
-    it("has mcp object with server entries having command + args", async () => {
+    it("has mcp object with server entries having command array + enabled", async () => {
       const ctx = makeCtx(tempDir);
       await opencodeAdapterMod.opencodeAdapter.syncMcp!(ctx);
 
@@ -627,9 +631,9 @@ describe("OpenCode adapter: structure validation", () => {
       assert(parsed.mcp !== null);
 
       for (const [_key, server] of Object.entries(parsed.mcp)) {
-        const srv = server as { command: string; args: string[] };
-        assertEquals(typeof srv.command, "string");
-        assert(Array.isArray(srv.args));
+        const srv = server as { command: string[]; enabled: boolean };
+        assert(Array.isArray(srv.command));
+        assertEquals(srv.enabled, true);
       }
     });
   });

--- a/pkg/@eserstack/noskills/sync/adapters/opencode.ts
+++ b/pkg/@eserstack/noskills/sync/adapters/opencode.ts
@@ -75,7 +75,13 @@ const buildExecutorAgentMd = (commandPrefix: string): string => {
     "---",
     "name: noskills-executor",
     'description: "Executes a single noskills task. Follows spec behavioral rules and reports structured results."',
-    "tools: read, write, glob, grep, shell, delegate",
+    "tools:",
+    "  read: true",
+    "  write: true",
+    "  glob: true",
+    "  grep: true",
+    "  shell: true",
+    "  delegate: true",
     "---",
     "",
     "You are executing a single task from a noskills spec.",
@@ -109,7 +115,11 @@ const buildVerifierAgentMd = (): string => {
     "---",
     "name: noskills-verifier",
     'description: "Independently verifies completed task work. Read-only. Never sees the executor\'s context."',
-    "tools: read, glob, grep, shell",
+    "tools:",
+    "  read: true",
+    "  glob: true",
+    "  grep: true",
+    "  shell: true",
     "---",
     "",
     "You are verifying another agent's work. You have NO context about how it was done.",
@@ -248,8 +258,8 @@ const buildSkillMd = (spec: ParsedSpec): string => {
 
 type OpenCodeMcpEntry = {
   readonly type: "local";
-  readonly command: string;
-  readonly args: readonly string[];
+  readonly command: readonly string[];
+  readonly enabled: boolean;
   readonly env?: Record<string, string>;
 };
 
@@ -386,8 +396,7 @@ export const opencodeAdapter: adapter.ToolAdapter = {
 
     // Build noskills MCP entry
     const parts = ctx.commandPrefix.split(/\s+/);
-    const command = parts[0] ?? "npx";
-    const args = [...parts.slice(1), "mcp-serve"];
+    const command = [...parts, "mcp-serve"];
 
     // Merge
     const merged: OpenCodeConfig = {
@@ -397,7 +406,7 @@ export const opencodeAdapter: adapter.ToolAdapter = {
         noskills: {
           type: "local",
           command,
-          args,
+          enabled: true,
         },
       },
     };


### PR DESCRIPTION
## Fixes issue

Fixes #128, Fixes #129

## Changes proposed

### Issue #129 — Agent tools field uses invalid string format

OpenCode schema expects `tools` as `object | undefined` in agent YAML frontmatter, but `noskills init` generated a comma-separated string.

**Before:**
```yaml
tools: read, write, glob, grep, shell, delegate
```

**After:**
```yaml
tools:
  read: true
  write: true
  glob: true
  grep: true
  shell: true
  delegate: true
```

Changed in `buildExecutorAgentMd()` and `buildVerifierAgentMd()` in `opencode.ts`.

### Issue #128 — MCP config uses invalid command/args structure

OpenCode schema expects `command` as `string[]` and requires `enabled: boolean`, but `noskills init` generated `command` as string + `args` array without `enabled`.

**Before:**
```json
{
  "mcp": {
    "noskills": {
      "type": "local",
      "command": "npx",
      "args": ["eser@latest", "noskills", "mcp-serve"]
    }
  }
}
```

**After:**
```json
{
  "mcp": {
    "noskills": {
      "type": "local",
      "command": ["npx", "eser@latest", "noskills", "mcp-serve"],
      "enabled": true
    }
  }
}
```

Changed in `OpenCodeMcpEntry` type and `syncMcp()` in `opencode.ts`.

### Tests

Updated 5 existing tests and re-structured 2 validation tests to cover the new schema format. Existing config preservation behavior is unchanged.

### Affected files

- `pkg/@eserstack/noskills/sync/adapters/opencode.ts`
- `pkg/@eserstack/noskills/sync/adapters/opencode.test.ts`

## Check List (Check all the applicable boxes)

- [x] The title of my pull request is a short description of the requested changes.
- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] This PR does not contain plagiarized content.
- [x] My submissions follows the **Submission Rules**
- [x] I have read and accepted the **Terms and Conditions**

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

- All existing tests pass (31/31), lint and type check are clean.
- Existing `opencode.json` configs with user-added MCP servers are preserved via deep merge — only the `noskills` entry is overwritten.
- The change is backward-compatible with the noskills manifest format; no migration needed.
- Other coding tool adapters (Claude Code, Codex CLI, Kiro, etc.) are not affected.
